### PR TITLE
Update "Nidoran shiny status & fix for correct path

### DIFF
--- a/pms.js
+++ b/pms.js
@@ -692,7 +692,7 @@ let pms = [
       "kr": "니드런♂",
       "zh": "尼多朗"
     },
-    "shiny_released": false,
+    "shiny_released": true,
     "released_date": "2019-07-04T08:00Z",
     "family": "Nidoran Male"
   },
@@ -706,7 +706,7 @@ let pms = [
       "kr": "니드리노",
       "zh": "尼多力諾"
     },
-    "shiny_released": false,
+    "shiny_released": true,
     "released_date": "2019-07-04T08:00Z",
     "family": "Nidoran Male"
   },
@@ -720,7 +720,7 @@ let pms = [
       "kr": "니드킹",
       "zh": "尼多王"
     },
-    "shiny_released": false,
+    "shiny_released": true,
     "released_date": "2019-07-04T08:00Z",
     "family": "Nidoran Male"
   },

--- a/script.js
+++ b/script.js
@@ -1,3 +1,9 @@
+//Obtaining data from LocalStorage to redirect the user
+let savedpath = localStorage.getItem("path")
+if savedpath != null {
+  window.replace(savedpath)
+}
+
 let elm = {};
 let today = new Date();
 elm.body = document.querySelector('body');
@@ -82,6 +88,10 @@ function nickname(value) {
   }
 }
 
+function setlocalstorage() {
+  localStorage.setItem("path",window.location.href);
+}
+
 
 let html = Object.values(pmsByFamily)
   .map(family => {
@@ -142,6 +152,9 @@ elm.checkList.addEventListener('change', (e) => {
   updateCheckboxState(pm, nextState[pm.dataset.state] || '1');
 
   let state = pm.dataset.state;
+
+  //Setting current path in LocalStorage
+  setlocalstorage()
 
   updateCheckedState(id, state);
   updateState();


### PR DESCRIPTION
- As Nidoran's male family shiny release was some days ago, the value is now 'true'.

- Now the PWA redirect the user to the correct path. It uses LocalStorage to save everytime the new path and when the PWA loads, it also redirects the user

P.S.
Sorry for the single PR, I wasn't able to create another one. In case, refuse it and I'll try to make two separate requests