### PR TITLE
Update pms.json: change Detective Hat Pikachu to new asset

### DIFF
--- a/assets/pms.json
+++ b/assets/pms.json
@@ -701,7 +701,7 @@
     "dex": 25,
     "isotope": "_23d",
     "released_date": "2023/10/05",
-    "aa_fn": "pm25.cFEB_2019",
+    "aa_fn": "pm25.cPI",
     "family": "Pikachu_23d"
   },
   {


### PR DESCRIPTION
It seems that a new asset was mined for detective hat pikachu. Some more info in this thread: https://github.com/PokeMiners/pogo_assets/issues/56