### PR TITLE
Update pms.json: add Go Tour 2024 - LA

### DIFF
--- a/assets/pms.json
+++ b/assets/pms.json
@@ -638,6 +638,34 @@
   },
   {
     "dex": 25,
+    "isotope": "_g24a",
+    "released_date": "2024/02/17",
+    "aa_fn": "pm25.fGOTOUR_2024_A",
+    "family": "Pikachu_gotour_24"
+  },
+  {
+    "dex": 25,
+    "isotope": "_g24b",
+    "released_date": "2024/02/17",
+    "aa_fn": "pm25.fGOTOUR_2024_A_02",
+    "family": "Pikachu_gotour_24"
+  },
+  {
+    "dex": 25,
+    "isotope": "_g24c",
+    "released_date": "2024/02/17",
+    "aa_fn": "pm25.fGOTOUR_2024_B",
+    "family": "Pikachu_gotour_24"
+  },
+  {
+    "dex": 25,
+    "isotope": "_g24d",
+    "released_date": "2024/02/17",
+    "aa_fn": "pm25.fGOTOUR_2024_B_02",
+    "family": "Pikachu_gotour_24"
+  },
+  {
+    "dex": 25,
     "isotope": "_23s",
     "released_date": "2023/04/04",
     "aa_fn": "pm25.cSPRING_2023",
@@ -1412,9 +1440,23 @@
     "released_date": "2020/05/08"
   },
   {
+    "dex": 100,
+    "family": "Voltorb",
+    "aa_fn": "pm100.fHISUIAN",
+    "isotope": "_01",
+    "released_date": "2024/02/17"
+  },
+  {
     "dex": 101,
     "family": "Voltorb",
     "released_date": "2020/05/08"
+  },
+  {
+    "dex": 101,
+    "family": "Voltorb",
+    "aa_fn": "pm101.fHISUIAN",
+    "isotope": "_01",
+    "released_date": "2024/02/17"
   },
   {
     "dex": 102,
@@ -2625,6 +2667,13 @@
     "dex": 211,
     "shiny_released": true,
     "family": "Qwilfish"
+  },
+  {
+    "dex": 211,
+    "family": "Qwilfish",
+    "aa_fn": "pm211.fHISUIAN",
+    "isotope": "_01",
+    "released_date": "2024/02/17"
   },
   {
     "dex": 212,
@@ -4294,6 +4343,8 @@
   {
     "dex": 433,
     "family": "Chimecho",
+    "released_date": "2024/02/17",
+    "aa_fn": "pm433",
     "order": -1
   },
   {
@@ -7060,6 +7111,8 @@
   },
   {
     "dex": 904,
+    "aa_fn": "pm904",
+    "released_date": "2024/02/17"
     "family": "Qwilfish"
   },
   {


### PR DESCRIPTION
the images for Hisuian Voltorb and Electrode are "outlines"--some kind of placeholder in pokeminer until the full assets are released. i think we can go ahead and use them for now in the shiny list--when the assets are updates, the list should automatically start using the new images, right?