### PR TITLE
Missing "," invalid JSON

### DIFF
--- a/assets/pms.json
+++ b/assets/pms.json
@@ -7141,7 +7141,7 @@
   {
     "dex": 904,
     "aa_fn": "pm904",
-    "released_date": "2024/02/17"
+    "released_date": "2024/02/17",
     "family": "Qwilfish"
   },
   {


### PR DESCRIPTION
A missing "," made the whole JSON invalid.