### PR TITLE
Add Sizzlipede family shiny release data (#581)

### DIFF
--- a/assets/pms.json
+++ b/assets/pms.json
@@ -8014,11 +8014,13 @@
   },
   {
     "dex": 850,
+    "aa_fn": "pm850",
     "released_date": "2026/03/17",
     "family": "sizzlipede"
   },
   {
     "dex": 851,
+    "aa_fn": "pm851",
     "released_date": "2026/03/17",
     "family": "sizzlipede"
   },


### PR DESCRIPTION
## Summary
- add the 2026/03/17 shiny release date for Sizzlipede and Centiskorch
- add explicit `aa_fn` values so the app uses the addressable asset filenames

Closes #581